### PR TITLE
Add GET all operation for RequestType table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/rec/controllers/RequestTypesController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/RequestTypesController.java
@@ -41,6 +41,19 @@ public class RequestTypesController extends ApiController {
     @Autowired
     RequestTypeRepository requestTypeRepository;
 
+        /**
+     * List all Request Types
+     * 
+     * @return an iterable of RequestType
+     */
+    @Operation(summary= "List all request types")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("/all")
+    public Iterable<RequestType> allRequestTypes() {
+        Iterable<RequestType> types = requestTypeRepository.findAll();
+        return types;
+    }
+
   
     /**
      * Create a new request type
@@ -107,7 +120,4 @@ public class RequestTypesController extends ApiController {
         requestTypeRepository.save(modifiedRequestType);
         return modifiedRequestType;
     }
-
-    
-
 }

--- a/src/test/java/edu/ucsb/cs156/rec/controllers/RequestTypesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/rec/controllers/RequestTypesControllerTests.java
@@ -80,6 +80,38 @@ public class RequestTypesControllerTests extends ControllerTestCase {
                                 .andExpect(status().is(403)); // only admins can post
         }
 
+        
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_user_can_get_all_ucsbdates() throws Exception {
+
+                // arrange
+
+                RequestType requestType1 = RequestType.builder()
+                                .requestType("CS Department BS/MS program")
+                                .build();
+
+                RequestType requestType2 = RequestType.builder()
+                                .requestType("Scholarship or Fellowship")
+                                .build();
+
+                ArrayList<RequestType> expectedRequestTypes = new ArrayList<>();
+                expectedRequestTypes.addAll(Arrays.asList(requestType1, requestType2));
+
+                when(requestTypeRepository.findAll()).thenReturn(expectedRequestTypes);
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/requesttypes/all"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(requestTypeRepository, times(1)).findAll();
+                String expectedJson = mapper.writeValueAsString(expectedRequestTypes);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
 
         @WithMockUser(roles = { "ADMIN", "USER" })
         @Test

--- a/src/test/java/edu/ucsb/cs156/rec/controllers/RequestTypesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/rec/controllers/RequestTypesControllerTests.java
@@ -50,6 +50,20 @@ public class RequestTypesControllerTests extends ControllerTestCase {
         // Authorization tests for /api/phones/admin/all
 
 
+        @Test
+        public void logged_out_users_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/requesttypes/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
+        
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/requesttypes/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+
+
         // Authorization tests for /api/phones/post
         // (Perhaps should also have these for put and delete)
 

--- a/src/test/java/edu/ucsb/cs156/rec/controllers/RequestTypesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/rec/controllers/RequestTypesControllerTests.java
@@ -62,8 +62,6 @@ public class RequestTypesControllerTests extends ControllerTestCase {
                 mockMvc.perform(get("/api/requesttypes/all"))
                                 .andExpect(status().is(200)); // logged
         }
-
-
         // Authorization tests for /api/phones/post
         // (Perhaps should also have these for put and delete)
 
@@ -79,11 +77,9 @@ public class RequestTypesControllerTests extends ControllerTestCase {
                 mockMvc.perform(post("/api/requesttypes/post"))
                                 .andExpect(status().is(403)); // only admins can post
         }
-
-        
         @WithMockUser(roles = { "USER" })
         @Test
-        public void logged_in_user_can_get_all_ucsbdates() throws Exception {
+        public void logged_in_user_can_get_all_requesttypes() throws Exception {
 
                 // arrange
 


### PR DESCRIPTION
Closes #37 
- Added RequestTypesController.java with the GET all method (at api/requesttypes/all)
- Added the associated tests which are all passing locally
- This branch was created off of rz-backendRequestTypeTable, but was rebased on main. The PR for the previous branch should be merged first

Deployed at https://rec-dev-ryanzanone.dokku-05.cs.ucsb.edu