### PR TITLE
Added DELETE operation for RequestType

### DIFF
--- a/src/main/java/edu/ucsb/cs156/rec/controllers/RequestTypesController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/RequestTypesController.java
@@ -55,6 +55,23 @@ public class RequestTypesController extends ApiController {
     }
 
     /**
+     * Get a single request type by id
+     * 
+     * @param id the id of the request type
+     * @return a RequestType
+     */
+    @Operation(summary= "Get a single request type")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public RequestType getById(
+            @Parameter(name="id") @RequestParam Long id) {
+        RequestType requestType = requestTypeRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(RequestType.class, id));
+
+        return requestType;
+    }
+
+    /**
      * Delete a RequestType
      * 
      * @param id the id of the request type to delete

--- a/src/main/java/edu/ucsb/cs156/rec/controllers/RequestTypesController.java
+++ b/src/main/java/edu/ucsb/cs156/rec/controllers/RequestTypesController.java
@@ -55,20 +55,21 @@ public class RequestTypesController extends ApiController {
     }
 
     /**
-     * Get a single request type by id
+     * Delete a RequestType
      * 
-     * @param id the id of the request type
-     * @return a RequestType
+     * @param id the id of the request type to delete
+     * @return a message indicating the request type was deleted
      */
-    @Operation(summary= "Get a single request type")
-    @PreAuthorize("hasRole('ROLE_USER')")
-    @GetMapping("")
-    public RequestType getById(
+    @Operation(summary= "Delete a Request Type")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteRequestType(
             @Parameter(name="id") @RequestParam Long id) {
         RequestType requestType = requestTypeRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException(RequestType.class, id));
 
-        return requestType;
+        requestTypeRepository.delete(requestType);
+        return genericMessage("RequestType with id %s deleted".formatted(id));
     }
   
     /**

--- a/src/test/java/edu/ucsb/cs156/rec/controllers/RequestTypesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/rec/controllers/RequestTypesControllerTests.java
@@ -70,6 +70,50 @@ public class RequestTypesControllerTests extends ControllerTestCase {
 
         // // Tests with mocks for database actions
 
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+                // arrange
+
+                RequestType requestType = RequestType.builder()
+                                .requestType("CS Department BS/MS program")
+                                .build();
+
+                when(requestTypeRepository.findById(eq(7L))).thenReturn(Optional.of(requestType));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/requesttypes?id=7"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(requestTypeRepository, times(1)).findById(eq(7L));
+                String expectedJson = mapper.writeValueAsString(requestType);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                when(requestTypeRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/requesttypes?id=7"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(requestTypeRepository, times(1)).findById(eq(7L));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("RequestType with id 7 not found", json.get("message"));
+        }
+
         @WithMockUser(roles = { "ADMIN", "USER" })
         @Test
         public void admin_can_delete_a_request_type() throws Exception {

--- a/src/test/java/edu/ucsb/cs156/rec/controllers/RequestTypesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/rec/controllers/RequestTypesControllerTests.java
@@ -47,26 +47,6 @@ public class RequestTypesControllerTests extends ControllerTestCase {
         @MockBean
         UserRepository userRepository;
 
-        // Authorization tests for /api/requesttypes/admin/all
-
-        @Test
-        public void logged_out_users_cannot_get_all() throws Exception {
-                mockMvc.perform(get("/api/requesttypes/all"))
-                                .andExpect(status().is(403)); // logged out users can't get all
-        }
-
-        @WithMockUser(roles = { "USER" })
-        @Test
-        public void logged_in_users_can_get_all() throws Exception {
-                mockMvc.perform(get("/api/requesttypes/all"))
-                                .andExpect(status().is(200)); // logged
-        }
-
-        @Test
-        public void logged_out_users_cannot_get_by_id() throws Exception {
-                mockMvc.perform(get("/api/requesttypes?id=7"))
-                                .andExpect(status().is(403)); // logged out users can't get by id
-        }
 
         // // Tests with mocks for database actions
 
@@ -145,6 +125,7 @@ public class RequestTypesControllerTests extends ControllerTestCase {
                 String responseString = response.getResponse().getContentAsString();
                 assertEquals(expectedJson, responseString);
         }
+
                 
         // Authorization tests for /api/phones/post
         // (Perhaps should also have these for put and delete)

--- a/src/test/java/edu/ucsb/cs156/rec/controllers/RequestTypesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/rec/controllers/RequestTypesControllerTests.java
@@ -105,7 +105,7 @@ public class RequestTypesControllerTests extends ControllerTestCase {
 
                 // act
                 MvcResult response = mockMvc.perform(
-                                delete("/api/requesttype?id=15")
+                                delete("/api/requesttypes?id=15")
                                                 .with(csrf()))
                                 .andExpect(status().isNotFound()).andReturn();
 

--- a/src/test/java/edu/ucsb/cs156/rec/controllers/RequestTypesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/rec/controllers/RequestTypesControllerTests.java
@@ -47,6 +47,26 @@ public class RequestTypesControllerTests extends ControllerTestCase {
         @MockBean
         UserRepository userRepository;
 
+        // Authorization tests for /api/requesttypes/admin/all
+
+        @Test
+        public void logged_out_users_cannot_get_all() throws Exception {
+                mockMvc.perform(get("/api/requesttypes/all"))
+                                .andExpect(status().is(403)); // logged out users can't get all
+        }
+        
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void logged_in_users_can_get_all() throws Exception {
+                mockMvc.perform(get("/api/requesttypes/all"))
+                                .andExpect(status().is(200)); // logged
+        }
+        @Test
+        public void logged_out_users_cannot_get_by_id() throws Exception {
+                mockMvc.perform(get("/api/requesttypes?id=7"))
+                                .andExpect(status().is(403)); // logged out users can't get by id
+        }
+
 
         // // Tests with mocks for database actions
 


### PR DESCRIPTION
Closes #43 
- Added the DELETE method to the RequestTypesController
- Added associated tests which are all passing locally
- This branch was created off of rz-backendRequestTypeTable, this should be merged before this branch

Deployed at https://rec.dokku-05.cs.ucsb.edu