### PR TITLE
Update 56-javadoc-main-branch.yml - don't fail on javadoc errors

### DIFF
--- a/.github/workflows/56-javadoc-main-branch.yml
+++ b/.github/workflows/56-javadoc-main-branch.yml
@@ -30,7 +30,7 @@ jobs:
          java-version-file: ./.java-version
   
     - name: Build javadoc
-      run: mvn -DskipTests javadoc:javadoc
+      run: mvn -DskipTests -Dmaven.javadoc.failOnError=false javadoc:javadoc
 
     - name: Deploy 🚀
       uses: JamesIves/github-pages-deploy-action@v4


### PR DESCRIPTION
In this PR, we override failing on javadoc errors.

There's a better way to fix this, which we should do after F24 is done.